### PR TITLE
Expose all of the algorithms to the streaming API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tested on node 0.10, 4.x, and 5.x.
 
 ## Usage
 
-Avon exports `sumFile`, 'sumBuffer', and `sumStream` functions to calculate a hash for whatever sort of data you have. All three functions take an optional callback. If no callback is provided, they return promises. Use the flow control method you prefer! The calculated hash is a node Buffer.
+Avon exports `sumFile()`, `sumBuffer()`, and `sumStream()` functions to calculate a hash for whatever sort of data you have. All three functions take an optional callback. If no callback is provided, they return promises. Use the flow control method you prefer! The calculated hash is a node Buffer.
 
 If you don't specify an algorithm, the 64-bit single-core `B` algorithm is used.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tested on node 0.10, 4.x, and 5.x.
 
 ## Usage
 
-All four functions take an optional callback. If no callback is provided, they return promises. Use the flow control method you prefer! The calculated hash is a node Buffer.
+Avon exports `sumFile`, 'sumBuffer', and `sumStream` functions to calculate a hash for whatever sort of data you have. All three functions take an optional callback. If no callback is provided, they return promises. Use the flow control method you prefer! The calculated hash is a node Buffer.
 
 If you don't specify an algorithm, the 64-bit single-core `B` algorithm is used.
 
@@ -39,7 +39,7 @@ Avon.sumBuffer(buf, function(err, buffer)
 {
 	if (err) console.error('noooo!');
 	else console.log(buffer.toString('hex'))
-})
+});
 ```
 
 There are variations that take a filename as input:
@@ -49,7 +49,7 @@ Avon.sumFile('my_file.dat', , Avon.ALGORITHMS.SP, function(err, buffer)
 {
 	if (err) console.error('noooo!');
 	else console.log(buffer.toString('hex'))
-})
+});
 ```
 
 Or create a stream:
@@ -70,15 +70,15 @@ input.pipe(hasher);
 
 ## API
 
-Algorithms: `Avon.ALGORITHMS` exports the enum-like list of algorithms: `B`, `BP`, `S`, and `SP`.
+`Avon.ALGORITHMS` exports the enum-like list of algorithms: `B`, `BP`, `S`, and `SP`.
 
-The following function are exported. This chart might help you decide which to use.
+Blake2 provides a bewildering variety of variations. Avon exposes all of them. This chart might help you decide which to use.
 
 | function | input | arch | multicore? | algo name
 | --- | --- | --- | --- | ---
-| sumStream | stream | both | both | pass algo name
-| sumBuffer | buffer | both | both | pass algo name
-| sumFile | file | 64 | both | both | pass algo name
+| sumStream | stream | * | * | pass algo name
+| sumBuffer | buffer | * | * | pass algo name
+| sumFile | file | * | * | pass algo name
 | blake2  | buffer | 64 | n | B
 | blake2SMP  | buffer | 64 | y | BP
 | blake2_32  | buffer | 32 | n | S

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ Tested on node 0.10, 4.x, and 5.x.
 
 All four functions take an optional callback. If no callback is provided, they return promises. Use the flow control method you prefer! The calculated hash is a node Buffer.
 
+If you don't specify an algorithm, the 64-bit single-core `B` algorithm is used.
+
 ```javascript
 var Avon = require('avon');
 var assert = require('assert');
 
 var buf = new Buffer('this is some input');
 
-Avon.sumBuffer(buf)
+Avon.sumBuffer(buf, Avon.ALGORITHMS.BP)
 .then(function(hash)
 {
 	assert(hash instanceof Buffer);
@@ -43,32 +45,18 @@ Avon.sumBuffer(buf, function(err, buffer)
 There are variations that take a filename as input:
 
 ```javascript
-Avon.sumFile('my_file.dat')
-.then(function(hash)
-{
-	assert(hash instanceof Buffer);
-	console.log(hash.toString('hex'));
-}, function(err)
-{
-	console.error('noooooo! ' + err.message);
-}).done();
-
-Avon.sumFile('my_file.dat', function(err, buffer)
+Avon.sumFile('my_file.dat', , Avon.ALGORITHMS.SP, function(err, buffer)
 {
 	if (err) console.error('noooo!');
 	else console.log(buffer.toString('hex'))
 })
 ```
 
-## Streams!
-
-The blake2 64-bit single core (aka blake2 b) algorithm is exposed with a streaming interface.
+Or create a stream:
 
 ```js
-var Avon = require('avon');
-
 var input = fs.createReadStream('my-large-file');
-var hasher = Avon.sumStream();
+var hasher = Avon.sumStream(Avon.ALGORITHMS.BP);
 
 input.on('close', function()
 {
@@ -82,26 +70,23 @@ input.pipe(hasher);
 
 ## API
 
+Algorithms: `Avon.ALGORITHMS` exports the enum-like list of algorithms: `B`, `BP`, `S`, and `SP`.
+
 The following function are exported. This chart might help you decide which to use.
 
-| function | input | arch | multicore? | blake name
+| function | input | arch | multicore? | algo name
 | --- | --- | --- | --- | ---
-| sumStream | stream | 64 | n | blake 2b
-| sumBuffer | buffer | 64 | n | alias for blake2()
-| sumFile | file | 64 | n | alias for blake2File()
-| blake2  | buffer | 64 | n | 2b
-| blake2SMP  | buffer | 64 | y | 2bp
-| blake2_32  | buffer | 32 | n | 2s
-| blake2_32SMP  | buffer | 32 | y | 2sp
-| blake2File | file | 64 | n | 2b
-| blake2SMPFile | file | 64 | y | 2bp
-| blake2_32File | file | 32 | n | 2s
-| blake2_32SMPFile | file | 32 | y | 2sp
-
-
-## TODO
-
-- Provide the other algorithms in streaming form.
+| sumStream | stream | both | both | pass algo name
+| sumBuffer | buffer | both | both | pass algo name
+| sumFile | file | 64 | both | both | pass algo name
+| blake2  | buffer | 64 | n | B
+| blake2SMP  | buffer | 64 | y | BP
+| blake2_32  | buffer | 32 | n | S
+| blake2_32SMP  | buffer | 32 | y | SP
+| blake2File | file | 64 | n | B
+| blake2SMPFile | file | 64 | y | BP
+| blake2_32File | file | 32 | n | S
+| blake2_32SMPFile | file | 32 | y | SP
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # avon
 
-Node bindings for the [blake2](https://blake2.net) cryptographic hash function.
+Node bindings for the [blake2](https://blake2.net) cryptographic hash function. The relationship of Avon to Blake is of course [obvious](https://en.wikipedia.org/wiki/Kerr_Avon).
 
 Blake2 provides four different hashing functions:
 

--- a/index.js
+++ b/index.js
@@ -38,10 +38,35 @@ function wrapperFile(algo, fname)
 	return deferred.promise;
 }
 
-// blake2bp - multicore, 64
+function sumBuffer(buffer, algorithm, callback)
+{
+	if (typeof algorithm === 'function')
+	{
+		callback = algorithm;
+		algorithm = B;
+	}
+	return wrapper(algorithm, buffer).nodeify(callback);
+}
+
+function sumFile(fname, algorithm, callback)
+{
+	if (typeof algorithm === 'function')
+	{
+		callback = algorithm;
+		algorithm = B;
+	}
+	return wrapperFile(algorithm, fname).nodeify(callback);
+}
 
 module.exports =
 {
+	// convenience wrappers
+	sumBuffer:  sumBuffer,
+	sumFile:    sumFile,
+	sumStream:  require('./streaming'),
+	ALGORITHMS: require('./streaming').ALGORITHMS,
+
+	// exposing the implementations
 	blake2:           function(buffer, callback) { return wrapper(B, buffer).nodeify(callback); },
 	blake2SMP:        function(buffer, callback) { return wrapper(BP, buffer).nodeify(callback); },
 	blake2_32:        function(buffer, callback) { return wrapper(S, buffer).nodeify(callback); },
@@ -50,9 +75,4 @@ module.exports =
 	blake2SMPFile:    function(fname, callback) { return wrapperFile(BP, fname).nodeify(callback); },
 	blake2_32File:    function(fname, callback) { return wrapperFile(S, fname).nodeify(callback); },
 	blake2_32SMPFile: function(fname, callback) { return wrapperFile(SP, fname).nodeify(callback); },
-	sumStream:        require('./streaming')
 };
-
-// Aliases for the most common.
-module.exports.sumBuffer = module.exports.blake2;
-module.exports.sumFile = module.exports.blake2File;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avon",
   "description": "node bindings for the blake2 cryptographic hash",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "author": "C J Silverio <ceejceej@gmail.com>",
   "bugs": {
     "url": "https://github.com/ceejbot/avon/issues"

--- a/src/avon.cc
+++ b/src/avon.cc
@@ -198,7 +198,7 @@ NAN_MODULE_INIT(InitAll)
 		Nan::New<String>("b2_buffer").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(HashBuffer)).ToLocalChecked()
 	);
-	Streamer::Initialize(target);
+	AvonStream::Initialize(target);
 }
 
 NODE_MODULE(blake2, InitAll)

--- a/src/streamer.cc
+++ b/src/streamer.cc
@@ -13,34 +13,12 @@
 using namespace v8;
 using namespace node;
 
-Streamer::Streamer(int algo)
-{
-	mLength = BLAKE2B_OUTBYTES;
-	blake2b_init(state, mLength);
-}
-
-Streamer::~Streamer() {}
-
-NAN_MODULE_INIT(Streamer::Initialize)
-{
-	v8::Local<v8::FunctionTemplate> t = Nan::New<v8::FunctionTemplate>(New);
-
-	t->SetClassName(Nan::New<String>("Streamer").ToLocalChecked());
-	t->InstanceTemplate()->SetInternalFieldCount(2);
-
-	Nan::SetPrototypeMethod(t, "update", UpdateB);
-	Nan::SetPrototypeMethod(t, "final", FinalB);
-
-	constructor().Reset(Nan::GetFunction(t).ToLocalChecked());
-	Nan::Set(target, Nan::New("Streamer").ToLocalChecked(), Nan::GetFunction(t).ToLocalChecked());
-}
-
-NAN_METHOD(Streamer::New)
+NAN_METHOD(AvonStream::New)
 {
 	if (info.IsConstructCall())
 	{
 		int algo = info[0]->IsUndefined() ? 0 : Nan::To<int>(info[0]).FromJust();
-		Streamer* obj = new Streamer(algo);
+		AvonStream* obj = new AvonStream(algo);
 		obj->Wrap(info.This());
 		info.GetReturnValue().Set(info.This());
 	}
@@ -53,28 +31,124 @@ NAN_METHOD(Streamer::New)
 	}
 }
 
-NAN_METHOD(Streamer::UpdateB)
+AvonStream::AvonStream(int algorithm)
 {
-	Streamer* hash = ObjectWrap::Unwrap<Streamer>(info.Holder());
+	switch (algorithm)
+	{
+		case B:
+		default:
+			mHash = new Blake2B();
+			break;
+
+		case BP:
+			mHash = new Blake2BP();
+			break;
+
+		case S:
+			mHash = new Blake2S();
+			break;
+
+		case SP:
+			mHash = new Blake2SP();
+			break;
+	}
+}
+
+AvonStream::~AvonStream()
+{
+	delete mHash;
+}
+
+NAN_METHOD(AvonStream::Update)
+{
+	AvonStream* obj = ObjectWrap::Unwrap<AvonStream>(info.Holder());
 	Local<Object> buffer = info[0].As<Object>();
 	size_t length = node::Buffer::Length(buffer);
 	char* data = node::Buffer::Data(buffer);
-	hash->Update(data, length);
+	obj->mHash->Update(data, length);
 }
 
-NAN_METHOD(Streamer::FinalB)
+NAN_METHOD(AvonStream::Final)
 {
-	Streamer* hash = ObjectWrap::Unwrap<Streamer>(info.Holder());
-	hash->Final();
-	info.GetReturnValue().Set(Nan::CopyBuffer((const char *)hash->mResult, hash->mLength).ToLocalChecked());
+	AvonStream* obj = ObjectWrap::Unwrap<AvonStream>(info.Holder());
+	obj->mHash->Final();
+	info.GetReturnValue().Set(Nan::CopyBuffer((const char *)obj->mHash->mResult, obj->mHash->mLength).ToLocalChecked());
 }
 
-void Streamer::Update(const void *buffer, size_t length)
+// --- blake2 algorithms
+
+Blake2B::Blake2B():Blake2Algorithm(BLAKE2B_OUTBYTES)
 {
-	blake2b_update(state, (unsigned char *)buffer, length);
+	blake2b_init(mState, mLength);
 }
 
-void Streamer::Final()
+void Blake2B::Update(const void *buffer, size_t length)
 {
-	blake2b_final(state, mResult, mLength);
+	blake2b_update(mState, (unsigned char *)buffer, length);
+}
+
+void Blake2B::Final()
+{
+	blake2b_final(mState, mResult, mLength);
+}
+
+Blake2BP::Blake2BP():Blake2Algorithm(BLAKE2B_OUTBYTES)
+{
+	blake2bp_init(mState, mLength);
+}
+
+void Blake2BP::Update(const void *buffer, size_t length)
+{
+	blake2bp_update(mState, (unsigned char *)buffer, length);
+}
+
+void Blake2BP::Final()
+{
+	blake2bp_final(mState, mResult, mLength);
+}
+
+Blake2S::Blake2S():Blake2Algorithm(BLAKE2S_OUTBYTES)
+{
+	blake2s_init(mState, mLength);
+}
+
+void Blake2S::Update(const void *buffer, size_t length)
+{
+	blake2s_update(mState, (unsigned char *)buffer, length);
+}
+
+void Blake2S::Final()
+{
+	blake2s_final(mState, mResult, mLength);
+}
+
+Blake2SP::Blake2SP():Blake2Algorithm(BLAKE2S_OUTBYTES)
+{
+	blake2sp_init(mState, mLength);
+}
+
+void Blake2SP::Update(const void *buffer, size_t length)
+{
+	blake2sp_update(mState, (unsigned char *)buffer, length);
+}
+
+void Blake2SP::Final()
+{
+	blake2sp_final(mState, mResult, mLength);
+}
+
+// --- v8 module ceremony
+
+NAN_MODULE_INIT(AvonStream::Initialize)
+{
+	v8::Local<v8::FunctionTemplate> t = Nan::New<v8::FunctionTemplate>(New);
+
+	t->SetClassName(Nan::New<String>("AvonStream").ToLocalChecked());
+	t->InstanceTemplate()->SetInternalFieldCount(2);
+
+	Nan::SetPrototypeMethod(t, "update", AvonStream::Update);
+	Nan::SetPrototypeMethod(t, "final", AvonStream::Final);
+
+	constructor().Reset(Nan::GetFunction(t).ToLocalChecked());
+	Nan::Set(target, Nan::New("AvonStream").ToLocalChecked(), Nan::GetFunction(t).ToLocalChecked());
 }

--- a/src/streamer.h
+++ b/src/streamer.h
@@ -4,32 +4,84 @@
 #include <node.h>
 #include "avon.h"
 
-class Streamer : public node::ObjectWrap
+class Blake2Algorithm
+{
+	public:
+		Blake2Algorithm(size_t len): mLength(len) {}
+		virtual ~Blake2Algorithm(){}
+
+		virtual void Update(const void *buffer, size_t length) = 0;
+		virtual void Final() = 0;
+
+		size_t mLength;
+		// The 2S hashes emit 32 bytes instead of 64, so we get away with this size.
+		unsigned char mResult[BLAKE2B_OUTBYTES];
+};
+
+class AvonStream : public node::ObjectWrap
 {
 	public:
 		static NAN_MODULE_INIT(Initialize);
 		static NAN_METHOD(New);
 
-		Streamer(int algorithm = 0);
-		void Update(const void *buffer, size_t length);
-		void Final();
-		size_t mLength;
-		// The 2S hashes emit 32 bytes instead of 64, so we get away with this size.
-		unsigned char mResult[BLAKE2B_OUTBYTES];
+		AvonStream(int algorithm = 0);
+		static NAN_METHOD(Update);
+		static NAN_METHOD(Final);
 
 	private:
-		~Streamer();
-
-		static NAN_METHOD(UpdateB);
-		static NAN_METHOD(FinalB);
+		~AvonStream();
+		Blake2Algorithm* mHash;
 
 		static inline Nan::Persistent<v8::Function> & constructor()
 		{
 			static Nan::Persistent<v8::Function> cons;
 			return cons;
 		}
-
-		blake2b_state state[1];
 };
+
+class Blake2B : public Blake2Algorithm
+{
+	public:
+		Blake2B();
+		void Update(const void *buffer, size_t length);
+		void Final();
+
+	private:
+		blake2b_state mState[1];
+};
+
+class Blake2BP : public Blake2Algorithm
+{
+	public:
+		Blake2BP();
+		void Update(const void *buffer, size_t length);
+		void Final();
+
+	private:
+		blake2bp_state mState[1];
+};
+
+class Blake2S : public Blake2Algorithm
+{
+	public:
+		Blake2S();
+		void Update(const void *buffer, size_t length);
+		void Final();
+
+	private:
+		blake2s_state mState[1];
+};
+
+class Blake2SP : public Blake2Algorithm
+{
+	public:
+		Blake2SP();
+		void Update(const void *buffer, size_t length);
+		void Final();
+
+	private:
+		blake2sp_state mState[1];
+};
+
 
 #endif

--- a/streaming.js
+++ b/streaming.js
@@ -34,6 +34,13 @@ StreamingWrap.prototype._write = function(data, encoding, callback)
 	callback();
 };
 
+StreamingWrap.prototype.update = function(data)
+{
+	if (typeof data === 'string') data = new Buffer(data);
+	assert(Buffer.isBuffer(data), 'better pass a buffer, buddy');
+	this.hash.update(data);
+};
+
 StreamingWrap.prototype.digest = function(type)
 {
 	this._finalized = true;

--- a/streaming.js
+++ b/streaming.js
@@ -6,16 +6,21 @@ var
 	util     = require('util')
 	;
 
+var ALGORITHMS = { 'B': 0, 'BP': 1, 'S': 2, 'SP': 3 };
+
 function createStreamingHash(algorithm)
 {
-	return new StreamingWrap();
+	if (typeof algorithm === 'string')
+		algorithm = ALGORITHMS[algorithm];
+	assert(typeof algorithm === 'number' && algorithm < 4, 'you must pass an algorithm number from Avon.ALGORITHMS');
+	return new StreamingWrap(algorithm);
 }
 
-function StreamingWrap(opts)
+function StreamingWrap(algorithm)
 {
 	this._finalized = false;
-	this.hash = new blake2.Streamer();
-	stream.Writable.call(this, opts);
+	this.hash = new blake2.AvonStream(algorithm);
+	stream.Writable.call(this);
 }
 util.inherits(StreamingWrap, stream.Writable);
 
@@ -38,3 +43,4 @@ StreamingWrap.prototype.digest = function(type)
 
 module.exports = createStreamingHash;
 createStreamingHash.StreamingWrap = StreamingWrap;
+createStreamingHash.ALGORITHMS = ALGORITHMS;

--- a/test/test-01-basic.js
+++ b/test/test-01-basic.js
@@ -9,6 +9,7 @@ var
 	;
 
 var correct2B = '7eb5d436ac77cb137329e74074501e484f4a9ed15f32b4be56842a8f285ebe4989cf89dd3794a8aee56e5964f3f5cd07f1b019611ce724141fd2a4b245d0d1a0';
+var correct2S = 'e58137b4c75c81b4b20bce99cc742335e3e9e8b8e57d2290670c8f3235f4bff3';
 var testp = path.resolve(__dirname, './test.png');
 var testbuffer;
 
@@ -24,7 +25,7 @@ describe('blake2', function()
 		});
 	});
 
-	describe('core', function()
+	describe('exports', function()
 	{
 		it('exports eight hash functions', function()
 		{
@@ -33,6 +34,7 @@ describe('blake2', function()
 			funcs.length.must.be.above(8);
 			for (var i = 0; i < funcs.length; i++)
 			{
+				if (funcs[i] === 'ALGORITHMS') return; // the one exception
 				Blake2[funcs[i]].must.be.a.function();
 			}
 		});
@@ -42,7 +44,7 @@ describe('blake2', function()
 			var funcs = Object.keys(Blake2);
 			funcs.forEach(function(f)
 			{
-				if (f === 'sumStream') return; // the one exception
+				if (f === 'sumStream' || f === 'ALGORITHMS') return; // the exceptions
 				var res = Blake2[f](testp);
 				res.must.be.an.object();
 				res.must.have.property('then');
@@ -63,11 +65,6 @@ describe('blake2', function()
 
 	describe('blake2 64-bit single core', function()
 	{
-		it('is aliased as sumBuffer', function()
-		{
-			Blake2.blake2.must.equal(Blake2.sumBuffer);
-		});
-
 		it('hashes a buffer correctly', function(done)
 		{
 			Blake2.blake2(testbuffer, function(err, hash)
@@ -92,11 +89,6 @@ describe('blake2', function()
 	describe('blake2File 64-bit single core', function()
 	{
 		var first;
-
-		it('is aliased as sumFile', function()
-		{
-			Blake2.blake2File.must.equal(Blake2.sumFile);
-		});
 
 		it('returns an error if it cannot find target file', function(done)
 		{
@@ -220,6 +212,42 @@ describe('blake2', function()
 				hash.toString('hex').must.equal(result);
 				done();
 			}).done();
+		});
+	});
+
+	describe('sumBuffer', function()
+	{
+		it('defaults to B if no algorithm is passed', function(done)
+		{
+			Blake2.sumBuffer(testbuffer, function(err, hash)
+			{
+				demand(err).not.exist();
+				hash.toString('hex').must.equal(correct2B);
+				done();
+			});
+		});
+	});
+
+	describe('sumFile', function()
+	{
+		it('defaults to B if no algorithm is passed', function(done)
+		{
+			Blake2.sumFile(testp, function(err, hash)
+			{
+				demand(err).not.exist();
+				hash.toString('hex').must.equal(correct2B);
+				done();
+			});
+		});
+
+		it('respects a passed-in algorithm', function(done)
+		{
+			Blake2.sumFile(testp, 2, function(err, hash)
+			{
+				demand(err).not.exist();
+				hash.toString('hex').must.equal(correct2S);
+				done();
+			});
 		});
 	});
 

--- a/test/test-02-streaming.js
+++ b/test/test-02-streaming.js
@@ -49,6 +49,29 @@ describe('blake2 streaming hash', function()
 		streamer.writable.must.be.true();
 	});
 
+	it('provides an update() function', function()
+	{
+		var result = createHash(Avon.ALGORITHMS.SP);
+		result.must.have.property('update');
+		result.update.must.be.a.function();
+	});
+
+	it('update() demands a string or buffer', function()
+	{
+		var hash = createHash(Avon.ALGORITHMS.SP);
+		function shouldThrow() { hash.update({ foo: 'bar' }); }
+		shouldThrow.must.throw(/buffer, buddy/);
+	});
+
+	it('update, like, does something', function()
+	{
+		var empty = createHash(Avon.ALGORITHMS.SP).digest('hex');
+		var hash = createHash(Avon.ALGORITHMS.SP);
+		hash.update('hello buddy');
+		var digest = hash.digest('hex');
+		digest.must.not.equal(empty);
+	});
+
 	it('provides a digest() function', function()
 	{
 		var result = createHash(Avon.ALGORITHMS.SP);

--- a/test/test-02-streaming.js
+++ b/test/test-02-streaming.js
@@ -5,10 +5,12 @@ var
 	demand     = require('must'),
 	fs         = require('fs'),
 	path       = require('path'),
+	Avon = require('../index'),
 	createHash = require('../index').sumStream
 	;
 
 var correct2B = '7eb5d436ac77cb137329e74074501e484f4a9ed15f32b4be56842a8f285ebe4989cf89dd3794a8aee56e5964f3f5cd07f1b019611ce724141fd2a4b245d0d1a0';
+var correct2S = 'e58137b4c75c81b4b20bce99cc742335e3e9e8b8e57d2290670c8f3235f4bff3';
 var testp = path.resolve(__dirname, './test.png');
 
 describe('blake2 streaming hash', function()
@@ -19,9 +21,23 @@ describe('blake2 streaming hash', function()
 		createHash.must.be.a.function();
 	});
 
+	it('throws if not passed an algorithm enum', function()
+	{
+		function shouldThrow() { return createHash(17); }
+		shouldThrow.must.throw(/algorithm number/);
+	});
+
 	it('can be constructed', function()
 	{
-		var streamer = createHash();
+		var streamer = createHash(Avon.ALGORITHMS.BP);
+		streamer.must.be.an.object();
+		streamer.constructor.name.must.equal('StreamingWrap');
+		streamer.must.be.instanceof(createHash.StreamingWrap);
+	});
+
+	it('can be constructed using a string', function()
+	{
+		var streamer = createHash('SP');
 		streamer.must.be.an.object();
 		streamer.constructor.name.must.equal('StreamingWrap');
 		streamer.must.be.instanceof(createHash.StreamingWrap);
@@ -29,27 +45,27 @@ describe('blake2 streaming hash', function()
 
 	it('implements stream.Writable', function()
 	{
-		var streamer = createHash(2);
+		var streamer = createHash(Avon.ALGORITHMS.BP);
 		streamer.writable.must.be.true();
 	});
 
 	it('provides a digest() function', function()
 	{
-		var result = createHash(2);
+		var result = createHash(Avon.ALGORITHMS.SP);
 		result.must.have.property('digest');
 		result.digest.must.be.a.function();
 	});
 
 	it('exposes a native update() function', function()
 	{
-		var result = createHash(2);
+		var result = createHash(Avon.ALGORITHMS.S);
 		result.hash.must.have.property('update');
 		result.hash.update.must.be.a.function();
 	});
 
 	it('exposes a native final() function', function()
 	{
-		var result = createHash(2);
+		var result = createHash(Avon.ALGORITHMS.BP);
 		result.hash.must.have.property('final');
 		result.hash.final.must.be.a.function();
 	});
@@ -57,7 +73,7 @@ describe('blake2 streaming hash', function()
 	it('can hash a file stream correctly', function(done)
 	{
 		var input = fs.createReadStream(testp);
-		var hasher = createHash(2);
+		var hasher = createHash(Avon.ALGORITHMS.B);
 
 		input.on('close', function()
 		{
@@ -69,9 +85,24 @@ describe('blake2 streaming hash', function()
 		input.pipe(hasher);
 	});
 
+	it('respects the algorithm parameter', function(done)
+	{
+		var input = fs.createReadStream(testp);
+		var hasher = createHash(Avon.ALGORITHMS.S);
+
+		input.on('close', function()
+		{
+			var digest = hasher.digest('hex');
+			digest.must.equal(correct2S);
+			done();
+		});
+
+		input.pipe(hasher);
+	});
+
 	it('throws if you attempt to update a finalized hash', function()
 	{
-		var hash = createHash();
+		var hash = createHash(Avon.ALGORITHMS.SP);
 		hash.digest('hex');
 		function shouldThrow() { hash.write(new Buffer('hello')); }
 		shouldThrow.must.throw(/finalized/);


### PR DESCRIPTION
Switch the API around yet again to make everything fairly sensible to use. `sumFile`, `sumBuffer`, and `sumStream` now take optional algorithm numbers; they still default to B.

The algorithm enum is now exported.

Expose update() on the streaming hash. This makes us more like the node crypto APIs. Add a bunch of tests for update() to make sure it's working.

Improve docs.