### PR TITLE
Fix build on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 node_js:
     - "4"
     - "6"
-    - "7"
+    - "8"
+    - "10"
 script: npm run travis
 after_success: npm run coverage
 env:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "~2.5.0",
+    "nan": "2.10.0",
     "p-promise": "~0.5.0",
     "readable-stream": "~2.2.2"
   },

--- a/src/avon.cc
+++ b/src/avon.cc
@@ -83,7 +83,7 @@ class FileWorker : public Nan::AsyncWorker
 				Nan::Null(),
 				Nan::CopyBuffer(hash, length).ToLocalChecked()
 			};
-			callback->Call(2, argv);
+			callback->Call(2, argv, async_resource);
 		};
 
 	private:


### PR DESCRIPTION
Hello @ceejbot, I've encountered problems building avon on node@10, trying to fix it with this PR.

Upgrading `nan` to 2.10.0 fixes deprecated `ForceSet`, specifically this error:

```
../node_modules/nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
         ~~~  ^
```

It would probably be enough [to upgrade just to 2.8](https://github.com/nodejs/nan/blob/master/CHANGELOG.md#280-nov-15-2017) but 2.10 works and all test pass so I left version at highest available.

`nan@2.9`, [specifically 6dd5fa69](https://github.com/nodejs/nan/commit/6dd5fa690af61ca3523004b433304c581b3ea309) deprecated calling callback without async context  – the second commit fixes this.

Tested on node 10.4.0, 8.11.2 and 6.14.2.